### PR TITLE
Fix broken input method context when UIExpandingTextView's height changed

### DIFF
--- a/IRCCloud/UIExpandingTextView.m
+++ b/IRCCloud/UIExpandingTextView.m
@@ -153,6 +153,9 @@
      
 -(void)setMaximumNumberOfLines:(int)n
 {
+    if (maximumNumberOfLines == n)
+        return;
+    
     NSRange saveSelection     = internalTextView.selectedRange;
     NSString *saveText        = internalTextView.text;
     NSString *newText         = @"-";
@@ -181,6 +184,9 @@
 
 -(void)setMinimumNumberOfLines:(int)m
 {
+    if (minimumNumberOfLines == m)
+        return;
+    
     NSRange saveSelection     = internalTextView.selectedRange;
     NSString *saveText        = internalTextView.text;
     NSString *newText         = @"-";


### PR DESCRIPTION
When `UIExpandingTextView`’s height changes, `setMaximumNumberOfLines` is called. The method always changes text property temporarily and restores it; therefore breaking input method context in some languages (e.g. Korean).

This commit prevents it by only doing things when the value is actually changed. It’s not a perfect solution, but it will work in most cases.
