### PR TITLE
Adds a basic swipe-to-dismiss functionality to ImageViewController

### DIFF
--- a/IRCCloud/Classes/ImageViewController.m
+++ b/IRCCloud/Classes/ImageViewController.m
@@ -130,6 +130,9 @@
         [self _showToolbar];
     [_hideTimer invalidate];
     _hideTimer = [NSTimer scheduledTimerWithTimeInterval:2 target:self selector:@selector(_hideToolbar) userInfo:nil repeats:NO];
+    
+    pScrollView.alwaysBounceHorizontal = (pScrollView.zoomScale > pScrollView.minimumZoomScale);
+    pScrollView.alwaysBounceVertical = (pScrollView.zoomScale > pScrollView.minimumZoomScale);
 }
 
 -(void)_showToolbar {
@@ -366,6 +369,10 @@
     UITapGestureRecognizer *doubleTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(doubleTap:)];
     [doubleTap setNumberOfTapsRequired:2];
     [_scrollView addGestureRecognizer:doubleTap];
+    
+    UISwipeGestureRecognizer *swipeRecognizer = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(swiped:)];
+    swipeRecognizer.direction = UISwipeGestureRecognizerDirectionDown | UISwipeGestureRecognizerDirectionUp;
+    [self.view addGestureRecognizer:swipeRecognizer];
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_gifProgress:) name:UIImageAnimatedGIFProgressNotification object:nil];
     [self willRotateToInterfaceOrientation:[UIApplication sharedApplication].statusBarOrientation duration:0];
@@ -391,6 +398,13 @@
         
         CGRect rectTozoom=CGRectMake(x, y, w, h);
         [_scrollView zoomToRect:rectTozoom animated:YES];
+    }
+}
+
+- (void)swiped:(UISwipeGestureRecognizer *)recognizer {
+    // Do not recognize when scrollview is zoomed in
+    if (_scrollView.zoomScale <= _scrollView.minimumZoomScale) {
+        [self doneButtonPressed:recognizer];
     }
 }
 


### PR DESCRIPTION
This PR uses a swipe gesture recognizer to allow swipe-to-dismiss when looking at an unzoomed image. It also enables bouncing (horizontal and vertical) when zoomed.

This implementation has interaction fairly similar to that of the Twitteriffic iOS app. Other apps (Facebook, Twitter) have a slightly more interesting interaction where the image view moves with the user's finger as it pans - but without also adding a fancier view controller transition animation, the disappearing image is fairly jarring.