### PR TITLE
Add upside down orientation to enable Slide Over & Split View.

### DIFF
--- a/IRCCloud/IRCCloud-Info.plist
+++ b/IRCCloud/IRCCloud-Info.plist
@@ -124,6 +124,7 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>


### PR DESCRIPTION
Adds the one missing orientation (all 4 are required) to enable Slide Over & Split View on the iPad.